### PR TITLE
Move campaign cvars from autoexec.cfg to cvar_defaults.cfg

### DIFF
--- a/cfg/autoexec.cfg
+++ b/cfg/autoexec.cfg
@@ -1,3 +1,0 @@
-// Default Campaign
-campaign_default P2CE_Mod_Template
-campaign_set_active P2CE_Mod_Template

--- a/cfg/cvar_defaults.cfg
+++ b/cfg/cvar_defaults.cfg
@@ -100,3 +100,7 @@ r_unlimitedrefract 1
 // Not needed for p2ce, causes some issues with collisions
 traceray_force_vphysics 0
 traceray_unshrink_vphysics_brushes 0
+
+// Default Campaign
+campaign_default P2CE_Mod_Template
+campaign_set_active P2CE_Mod_Template


### PR DESCRIPTION
I've just noticed that the Exit button on the main menu in the P2CE Mod Template exits you out of the current campaign rather than the sourcemod itself.

This issue can even be seen on the example sceenshot of the main menu (right where it says "Leave the current campaign/map")
<img width="1920" height="1080" alt="mod_template_main_menu" src="https://github.com/user-attachments/assets/90f54593-f373-48ed-b6ae-c8a674c1de2a" />

This can be fixed by moving the campaign convars from autoexec.cfg to cvar_defaults.cfg